### PR TITLE
backend: initialize patch-setting route for user setting

### DIFF
--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,16 @@
+import { trim } from "@/packages/utils/functions/trim";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+
+
+const updateUserSchema = z.object({
+    name: z.preprocess(trim, z.string().min(1).max(64)).optional(),
+    avatar: z.preprocess(trim, z.string()).optional(),
+    email: z.preprocess(trim, z.string().min(4)).optional()
+})
+
+
+// Route:PATCH: - /api/user/ -update information about user
+export async function PATCH(request: NextRequest) {
+
+}

--- a/src/packages/utils/functions/trim.ts
+++ b/src/packages/utils/functions/trim.ts
@@ -1,0 +1,1 @@
+export const trim = (u: unknown) => (typeof u === "string" ? u.trim() : u);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Sets up the PATCH /api/user endpoint for updating user settings with input validation. Adds a shared trim utility to normalize incoming strings.

- **New Features**
  - Initialize scaffold for PATCH /api/user.
  - Add Zod schema with trim preprocessing: name (1–64), avatar, email (min 4).
  - Introduce utils/functions/trim.ts.

<!-- End of auto-generated description by cubic. -->

